### PR TITLE
XZ-323: Added window border toggle to windows and linux

### DIFF
--- a/examples/common/entry/entry.h
+++ b/examples/common/entry/entry.h
@@ -289,6 +289,9 @@ namespace entry
 	void toggleFullscreen(WindowHandle _handle);
 
 	///
+	void showWindowFrame(WindowHandle _handle, bool _show);
+
+	///
 	void setMouseLock(WindowHandle _handle, bool _lock);
 
 	///

--- a/examples/common/entry/entry_x11.cpp
+++ b/examples/common/entry/entry_x11.cpp
@@ -781,6 +781,32 @@ namespace entry
 		BX_UNUSED(_handle);
 	}
 
+	void showWindowFrame(WindowHandle _handle, bool _show)
+	{
+		typedef struct Hints
+		{
+			unsigned long   flags;
+			unsigned long   functions;
+			unsigned long   decorations;
+			long            inputMode;
+			unsigned long   status;
+		} Hints;
+
+		Hints hints;
+		Atom property;
+		hints.flags = 2;
+		hints.decorations = _show;
+		property = XInternAtom(s_ctx.m_display, "_MOTIF_WM_HINTS", true);
+		XChangeProperty(s_ctx.m_display,
+						s_ctx.m_window[_handle.idx],
+						property,
+						property,
+						32,
+						PropModeReplace,(unsigned char *)&hints,
+						5);
+		XMapWindow(s_ctx.m_display, s_ctx.m_window[_handle.idx]);
+	}
+
 	void setMouseLock(WindowHandle _handle, bool _lock)
 	{
 		BX_UNUSED(_handle, _lock);


### PR DESCRIPTION
Added application window border visibility toggle support to bgfx (which it didn't have).
Both for Windows and Linux, we need this for the AR/Stereo mode rendering in which we should display a borderless canvas to be displayed on HardHat vs the normal desktop mode in which we have the window borders visible.